### PR TITLE
Handle line continuations

### DIFF
--- a/decomment
+++ b/decomment
@@ -3,6 +3,8 @@
 $/ = undef;   # no line delimiter
 $_ = <>;   # read entire file
 
+s!\\\n!!g;   # handle line continuations
+
 s! ((['"]) (?: \\. | .)*? \2) | # skip quoted strings
    /\* .*? \*/ |  # delete C comments
    // [^\n\r]*   # delete C++ comments


### PR DESCRIPTION
I've had some troubles with shortC recently when I tried to add another language to the big polyglot.
The problem is that shortC is the only language in C family that doesn't support line continuations. 
This PR fixes that.

Or is this the intended behavior considering that `\` gets transpiled? You may think it would be confusing if `\` behaved differently depending on whether it is at the end of the line or not, but it already behaves differently inside strings and comments, so it doesn't seem like a problem to me.

I've checked [all the 51 shortC answers](https://codegolf.stackexchange.com/search?q=shortC) on codegolf, none of them use `\` at the end of the line.